### PR TITLE
Add default value in my server

### DIFF
--- a/core/src/io/anuke/mindustry/core/Control.java
+++ b/core/src/io/anuke/mindustry/core/Control.java
@@ -110,7 +110,7 @@ public class Control extends Module{
 			"ip", "localhost",
 			"port", port+"",
 			"name", mobile || gwt ? "player" : UCore.getProperty("user.name"),
-			"servers", "",
+			"servers", "mindustry.kr:6570|||",
 			"color", Color.rgba8888(playerColors[8]),
 			"lastVersion", "3.2",
 			"lastBuild", 0


### PR DESCRIPTION
The first community server that started on February 21, 2018 has returned!
This was possible because 3.5 versions of server data were not deleted.
Can you trust my server?

old domain: mindustry.oa.to <- oa.to domain is dead